### PR TITLE
Fix geckodriver on aarch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 __pycache__/
+geckodriver

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ ENV TZ=Europe/London
 RUN apk add --no-cache firefox
 RUN apk add --no-cache tesseract-ocr
 RUN apk add --no-cache tesseract-ocr-data-eng
-#Zlib is required for armv7
-RUN apk add zlib-dev
+
 
 #Copy the code
 WORKDIR /app
@@ -18,6 +17,9 @@ COPY . /app
 
 #Install the python requirements
 RUN pip3 install -r /app/requirements.txt
+
+#Install geckodriver
+RUN python3 /app/src/setup.py
 
 #Make sure the startup script is executable
 RUN chmod +x /app/startup.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ packaging==24.0
 pillow==10.3.0
 PySocks==1.7.1
 pytesseract==0.3.10
-python-dotenv==1.0.1
 requests==2.31.0
 selenium==4.20.0
 sniffio==1.3.1
@@ -18,5 +17,4 @@ trio==0.25.0
 trio-websocket==0.11.1
 typing-extensions==4.11.0
 urllib3==2.2.1
-webdriver-manager==4.0.1
 wsproto==1.2.0

--- a/src/installGecko.py
+++ b/src/installGecko.py
@@ -1,0 +1,68 @@
+import requests
+import os
+from platform import machine
+import gzip
+import gnupg
+
+def get_architecture():
+    # Get the machine architecture
+    arch = machine()
+    if arch == "x86_64":
+        return "linux64"
+    elif arch == "AMD64":
+        return "linux64"
+    elif arch == "arm64":
+        return "linux-aarch64"
+    elif arch == "aarch64":
+        return "linux-aarch64"
+    else:
+        raise ValueError(f"Unsupported architecture: {arch}")
+
+def download_asset(url):
+    # Extract the filename from the URL
+    filename = os.path.join("./", os.path.basename(url))
+    # Download the asset
+    response = requests.get(url)
+    if response.status_code == 200:
+        # Write the downloaded content to a temporary file
+        temp_filename = filename + '.temp'
+        with open(temp_filename, 'wb') as f:
+            f.write(response.content)
+
+        # Extract the .gz file
+        with gzip.open(temp_filename, 'rb') as gz_file:
+            with open(filename, 'wb') as f:
+                f.write(gz_file.read())
+
+        # Remove the temporary file
+        os.remove(temp_filename)
+
+        print(f"Downloaded and extracted: {filename}")
+    else:
+        print(f"Failed to download asset: {response.status_code}")
+
+def fetch_latest_assets(owner, repo):
+    # Fetch information about the latest release
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()
+        # Download assets associated with the release
+        architecture = get_architecture()
+        for asset in data.get('assets', []):
+            if architecture in asset['name']:
+                download_asset(asset['browser_download_url'])
+    else:
+        print(f"Failed to fetch latest release: {response.status_code}")
+
+def verify_signature(signed_file, original_file):
+    gpg = gnupg.GPG()
+    with open(signed_file, 'rb') as f:
+        verified = gpg.verify_file(f, original_file)
+        if verified:
+            print(f"Signature verification successful: {signed_file}")
+        else:
+            print(f"Signature verification failed: {signed_file}")
+
+if __name__ == "__main__":
+    fetch_latest_assets("mozilla", "geckodriver")

--- a/src/loadFirefox.py
+++ b/src/loadFirefox.py
@@ -3,13 +3,16 @@ from selenium import webdriver
 from selenium.webdriver.firefox.service import Service
 from selenium.webdriver.firefox.options import Options
 
-from webdriver_manager.firefox import GeckoDriverManager
-
 
 #Load the browser
 def loadFirefox():
     options = Options()
     options.add_argument("--headless")
     
-    return webdriver.Firefox(service=Service(GeckoDriverManager().install()),
-    options=options)
+    return webdriver.Firefox(service=Service("/app/geckodriver"), options=options)
+
+if __name__ == "__main__":
+    driver = loadFirefox()
+    driver.get("https://example.com")
+    print(driver.title)
+    driver.quit()

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,0 +1,67 @@
+import requests
+from os import path, remove
+from platform import machine
+import tarfile
+
+def main():
+    # Fetch the latest release assets for the repository
+    print("Setting up geckodriver")
+    fetch_latest("mozilla", "geckodriver")
+
+
+def get_architecture():
+    # Get the machine architecture
+    arch = machine()
+    if arch == "x86_64":
+        return "linux64"
+    elif arch == "AMD64":
+        return "linux64"
+    elif arch == "arm64":
+        return "linux-aarch64"
+    elif arch == "aarch64":
+        return "linux-aarch64"
+    else:
+        raise ValueError(f"Unsupported architecture: {arch}")
+
+def download_asset(url):
+    print(f"Downloading: {url}")
+    # Extract the filename from the URL
+    filename = path.join("./", path.basename(url))
+    # Download the asset
+    response = requests.get(url)
+    if response.status_code == 200:
+        #Save the asset to the current directory
+        with open(filename, 'wb') as file:
+            file.write(response.content)
+        # Extract the contents of the archive
+        print(f"Extracting to: {filename}")
+        with tarfile.open(filename, 'r:gz') as tar:
+            tar.extractall()
+        # Remove the archive file
+        remove(filename)
+
+        # Check for the geckodriver binary
+        if path.exists("geckodriver"):
+            print("geckodriver is setup")
+        else:
+            exit("Failed to download geckodriver binary")        
+    else:
+        exit(f"Failed to download asset: {response.status_code}")
+
+def fetch_latest(owner, repo):
+    # Fetch information about the latest release
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()
+        # Download assets associated with the release
+        architecture = get_architecture()
+        for asset in data.get('assets', []):
+            # Download the asset if it matches the architecture and is a gz archive
+            if architecture in asset["name"] and asset["name"].endswith('.gz'):
+                download_asset(asset['browser_download_url'])
+    else:
+        exit(f"Failed to fetch latest release: {response.status_code}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Completely reimplement Firefox loading to fix wrong geckodriver being installed on arm.

Instead of webdriver-manager, use a simple python script to pull the latest geckodriver with the correct arch.
webdriver-manager currently has a bug detecting aarch machines.